### PR TITLE
Urlquote recipes with spaces in its name when GitHub searching (#664)

### DIFF
--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -20,6 +20,7 @@ import json
 import os
 import re
 import tempfile
+from urllib.parse import quote
 from typing import List, Optional
 
 from autopkglib import get_pref, log, log_err
@@ -164,7 +165,8 @@ To save the token, paste it to the following prompt."""
     ):
         """Search GitHub for results for a given name."""
 
-        query = f"q={name}+extension:recipe+user:{user}"
+        query = f"q={quote(name)}+extension:recipe+user:{user}"
+
         if path_only:
             query += "+in:path,filepath"
         else:


### PR DESCRIPTION
* Escaped spaces with %20

* Changed string.replace by urllib.parse.quote(string)

* [query] No need of temporary variable